### PR TITLE
docs: added badge to readme & lower java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
+# OOP Project - Video Store CMS
+![Test](https://github.com/catouberos/video-store/actions/workflows/test.yml/badge.svg)
+![Build](https://github.com/catouberos/video-store/actions/workflows/build.yml/badge.svg)
+
 ## Getting started
 ### Prerequisite
-- Java >= 19 (preferrably [OpenJDK](https://openjdk.org/))
+- Java >= 17
 
 ### Contribute
 This project was made with the [Gradle Build Tool](https://gradle.org/), which you can build with the follow command:
 ```sh
 ./gradlew build
 ```
-...or on Windows with
+...or on Windows with:
 ```batch
 gradlew.bat build
 ```
@@ -17,4 +21,4 @@ When running `build`, Gradle will also runs `spotlessCheck`, which will run a ch
 ./gradlew spotlessApply
 ```
 
-Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification while commit-ing
+Please follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification while commit.


### PR DESCRIPTION
## Describe your changes
- Changed prerequisites Java version to 17
- Added Github Actions' badges to `README.md`, includes: ![Test](https://github.com/catouberos/video-store/actions/workflows/test.yml/badge.svg) ![Build](https://github.com/catouberos/video-store/actions/workflows/build.yml/badge.svg)