### PR TITLE
fix: null check on User setters

### DIFF
--- a/src/main/java/pls_no_shinobu/videostore/model/User.java
+++ b/src/main/java/pls_no_shinobu/videostore/model/User.java
@@ -138,7 +138,7 @@ public class User extends Entity {
      * @author Tran The Quang Minh
      */
     public void setName(String name) throws IllegalArgumentException {
-        if (getName().contains(name)) throw new IllegalArgumentException("Name is unchanged");
+        if (getName() != null && getName().contains(name)) throw new IllegalArgumentException("Name is unchanged");
 
         this.name = name;
     }
@@ -159,7 +159,7 @@ public class User extends Entity {
      * @author Tran The Quang Minh
      */
     public void setAddress(String address) throws IllegalArgumentException {
-        if (getAddress().contains(address))
+        if (getAddress() != null && getAddress().contains(address))
             throw new IllegalArgumentException("Address is unchanged");
 
         this.address = address;
@@ -181,7 +181,7 @@ public class User extends Entity {
      * @author Tran The Quang Minh
      */
     public void setPhone(String phone) throws IllegalArgumentException {
-        if (getPhone().contains(phone))
+        if (getPhone() != null && getPhone().contains(phone))
             throw new IllegalArgumentException("Phone number is unchanged");
 
         this.phone = phone;

--- a/src/main/java/pls_no_shinobu/videostore/model/User.java
+++ b/src/main/java/pls_no_shinobu/videostore/model/User.java
@@ -138,7 +138,8 @@ public class User extends Entity {
      * @author Tran The Quang Minh
      */
     public void setName(String name) throws IllegalArgumentException {
-        if (getName() != null && getName().contains(name)) throw new IllegalArgumentException("Name is unchanged");
+        if (getName() != null && getName().contains(name))
+            throw new IllegalArgumentException("Name is unchanged");
 
         this.name = name;
     }


### PR DESCRIPTION
Before this, setting any value on `User` class wouldn't pass (incl. constructor), because there wasn't any value to begin with for checking duplicates/unchanged values.
This PR fixes this.